### PR TITLE
Added prompt to ensure that the LaTeX code generated correctly.

### DIFF
--- a/task_generator/prompts_raw/prompt_code_generation.txt
+++ b/task_generator/prompts_raw/prompt_code_generation.txt
@@ -39,6 +39,7 @@ Scene Technical Implementation:
 18. **Animation Timings and Narration Sync:** Implement animations with precise `run_time` values and synchronize them with the narration script according to the Animation and Narration Plan. Use `Wait()` commands with specified durations for transition buffers.
 19. **Don't be lazy on code generation:** Generate full, complete code including all helper functions. Ensure that the output is comprehensive and the code is fully functional, incorporating all necessary helper methods and complete scene implementation details.
 20. **LaTeX Package Handling:** If the technical implementation plan specifies the need for additional LaTeX packages:
+    *   **LaTeX Special Character Handling:** Ensure that all special characters in LaTeX text (such as underscores _, percent signs %, hash symbols #, dollar signs $, etc.) are properly escaped. For example, add_intro should be written as add\_intro. For mathematical expressions (like O(n^2)), make sure they are enclosed in math mode using $O(n^2)$ or \(O(n^2)\).
     *   Create a `TexTemplate` object.
     *   Use `myTemplate = TexTemplate()`
     *   Use `myTemplate.add_to_preamble(r"\\usepackage{{package_name}}")` to add the required package.

--- a/task_generator/prompts_raw/prompt_scene_technical_implementation.txt
+++ b/task_generator/prompts_raw/prompt_scene_technical_implementation.txt
@@ -28,6 +28,7 @@ The following manim plugins are relevant to the scene:
 
 **Common Mistakes:**
 *   The Triangle class in Manim creates equilateral triangles by default. To create a right-angled triangle, use the Polygon class instead.
+*   **LaTeX Text Handling Error:** When generating text that includes LaTeX, ensure that all special characters are properly escaped. For mathematical expressions (such as O(n^2)), make sure they are enclosed in math mode using $O(n^2)$. This is because LaTeX interprets unescaped underscores and superscript symbols as the beginning of math mode, which can lead to compilation errors.
 
 **Manim Plugins:**
 *   You may use established, well-documented Manim plugins if they offer significant advantages in terms of code clarity, efficiency, or functionality not readily available in core Manim.


### PR DESCRIPTION
Added a prompt to ensure that the LaTeX code generated by o3-mini correctly wraps mathematical expressions with escape characters.

Added correction logic after line 41 in TheoremExplainAgent/task_generator/prompts_raw/prompt_code_generation.txt:
LaTeX Special Character Handling: Ensure that all special characters in LaTeX text (such as underscores _, percent signs %, hash symbols #, dollar signs $, etc.) are properly escaped. For example, add_intro should be written as add\_intro. For mathematical expressions (like O(n^2)), make sure they are enclosed in math mode using $O(n^2)$ or \(O(n^2)\).

Added correction logic after line 30 in task_generator/prompts_raw/prompt_scene_technical_implementation.txt:
LaTeX Text Handling Error: When generating text that includes LaTeX, ensure that all special characters are properly escaped. For mathematical expressions (such as O(n^2)), make sure they are enclosed in math mode using $O(n^2)$. This is because LaTeX interprets unescaped underscores and superscript symbols as the beginning of math mode, which can lead to compilation errors.